### PR TITLE
German: Correct grammar/spelling, rephrase for better text quality

### DIFF
--- a/german/index.html
+++ b/german/index.html
@@ -25,7 +25,7 @@
 		<div class="page-footer absolute-footer no-auto-footer">Revision 3</div>
         <div class="page-content">
 			<img src="/assets/img/ktane-logo.png" alt="Keep Talking and Nobody Explodes" style="margin: 1em auto .2em; width: 42em;" />
-    	    <h1 style="font-size: 1em; font-weight: normal; margin: 3.85em auto 0;"><span style="font-size: 8.9em; line-height: 1.13em;">BOMBEN</span><br /><span style="font-size: 4.1em; line-height: 0em;">ENTSCHÄRFUNGS</span><br /><span style="font-size: 6.7em; line-height: 1.1em;">HANDBUCH</span></h1>
+    	    <h1 style="font-size: 1em; font-weight: normal; margin: 3.85em auto 0;"><span style="font-size: 8.4em; line-height: 1.13em;">BOMBEN</span><span style="font-size: 6em; line-height: 1.13em;">-</span><br /><span style="font-size: 4.1em; line-height: 0em;">ENTSCHÄRFUNGS-</span><br /><span style="font-size: 7.2em; line-height: 1.1em;">HANDBUCH</span></h1>
 			<h2 style="margin: 1.2em auto; text-decoration: none; line-height: 1em; font-size: 2.8em;">Version 1							<br />
 				<span style="font-size: 0.57em; font-weight: normal;">Verification Code: 241</span>
 						</h2>
@@ -44,8 +44,8 @@
             <div class="vertical-spacer"></div>
 
             <p style="font-style:italic;">Willkommen in der gefährlichen und herausfordernden Welt der Bombenentschärfung.</p>
-            <p style="font-style:italic;">Studieren Sie dieses Handbuch sorgfältig; <em style="font-style:italic;">Sie sind der Experte</em>. Auf diesen Seiten werden Sie alles finden, was Sie brauche, um selbst die heimtückischsten Bomben zu entschärfen.<br />Und denken Sie daran - Eine kleine Unachtsamkeit und es könnte alles vorüber sein!</p>
-            <p style="font-style:italic;">Inoffizielle Deutsche Version</p>
+            <p style="font-style:italic;">Studieren Sie dieses Handbuch sorgfältig; <em style="font-style:italic;">Sie sind der Experte</em>. Auf diesen Seiten werden Sie alles finden, was Sie brauchen, um selbst die heimtückischsten Bomben zu entschärfen.<br />Und denken Sie daran - eine kleine Unachtsamkeit und es könnte alles vorüber sein!</p>
+            <p style="font-style:italic;">Inoffizielle deutsche Version</p>
         </div>
         <div class="page-footer relative-footer"></div>
     </div>
@@ -73,11 +73,11 @@
 
             <h3>Fehler</h3>
 			<div class="timer-diagram">Fehleranzeige<br /><img src="/assets/img/TimerComponent.svg"/></div>
-            <p>Wenn die entschärfende Person einen Fehler macht, wird die Bombe diesen Fehler bemerken und in der Fehleranzeige die Anzahl der Fehler darstellen. Bombem mit Fehleranzeige explodieren beim dritten Fehler. Der Countdown zählt schneller, wenn ein Fehler bemerkt wurde.</p>
-			<p>Wenn es keine Fehleranzeige über dem Countdown-Timer gibt, wird die Bombe beim ersten gemachten Fehler explodieren.</p>
+            <p>Wenn die entschärfende Person einen Fehler macht, wird die Bombe diesen Fehler festhalten und in der Fehleranzeige über dem Countdown-Timer darstellen. Bomben mit Fehleranzeige explodieren beim dritten Fehler. Der Countdown zählt schneller, nachdem ein Fehler bemerkt wurde.</p>
+			<p>Gibt es keine Fehleranzeige über dem Countdown-Timer, wird die Bombe beim ersten gemachten Fehler explodieren.</p>
 
 			<h3>Informationen sammeln</h3>
-			<p>Manche Entschärfungsanleitungen benötigen spezifische Informationen über die Bombe, zum Beispiel die Seriennummer. Diese Art von Information ist üblicherweise oben, an den Seiten oder unter dem Bombengehäuse zu finden (siehe Anhang A, B, und C).</p>
+			<p>Manche Entschärfungsanleitungen benötigen spezifische Informationen über die Bombe, wie etwa die Seriennummer. Diese Art von Information ist üblicherweise oben, an den Seiten oder unter dem Bombengehäuse zu finden (siehe Anhang A, B und C).</p>
         </div>
         <div class="page-footer relative-footer"></div>
     </div>
@@ -110,19 +110,19 @@
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
     	    <img src="/assets/img/WireComponent.svg" class="diagram" />
-            <h2>Bezüglich Kabel</h2>
+            <h2>Bezüglich der Kabel</h2>
             <p class="flavour-text">
                 Kabel sind das Blut der Elektronik! Nein, warte, Elektrizität ist das Blut. Kabel sind eher wie die Arterien. Die Venen? Egal…</p>
 
 			<ul>
-				<li>Ein Kabelmodul kann 3-6 Kabel enthalten.</li>
-				<li>Es gibt genau <em>ein</em> korrektes Kabel, das durchgeschnitten werden muss, um das Modul zu entschärfen.</li>
+				<li>Ein Kabelmodul kann 3 bis 6 Kabel enthalten.</li>
+				<li>Es gibt genau <em>ein</em> richtiges Kabel, das durchgeschnitten werden muss, um das Modul zu entschärfen.</li>
 
-				<li>Die Reihenfolge der Kabel beginnt mit dem Obersten.</li>
+				<li>Die Reihenfolge der Kabel beginnt mit dem obersten.</li>
 			</ul>
 
 			<table>
-				<tr><td><strong><em>3 Kabel:</em></strong>	<br />Wenn es keine roten Kabel gibt, das zweite Kabel durchschneiden.<br />Ansonsten, wenn das letzte Kabel weiß ist, das letzte Kabel durchschneiden.<br />Ansonsten, wenn es mehr als ein blaues Kabel gibt, das letzte blaue Kabel durchschneiden.<br />Ansonsten, das letzte Kabel durchschneiden.</tr><tr><td><strong><em>4 Kabel:</em></strong><br />Wenn es mehr als ein rotes Kabel gibt, und die letzte Ziffer der Seriennummer ungerade ist, das letzte rote Kabel durchschneiden.<br />Ansonsten, wenn das letzte Kabel gelb ist und es keine roten Kabel gibt, das erste Kabel durchschneiden.<br />Ansonsten, wenn es genau ein blaues Kabel gibt, das erste Kabel durchschneiden.<br />Ansonsten, wenn es mehr als ein gelbes Kabel gibt, das letzte Kabel durchschneiden.<br />Ansonsten, das zweite Kabel durchschneiden.</tr><tr><td><strong><em>5 Kabel:</em></strong><br />Wenn das letzte Kabel schwarz ist, und die letzte Ziffer der Seriennummer ungerade, das vierte Kabel durchschneiden.<br />Ansonsten, wenn es genau ein rotes Kabel gibt, und mehr als ein gelbes Kabel, das erste Kabel durchschneiden.<br />Ansonsten, wenn es keine schwarzen Kabel gibt, das zweite Kabel durchschneiden.<br />Ansonsten, das erste Kabel durchschneiden.</tr><tr><td><strong><em>6 Kabel:</em></strong><br />Wenn es keine gelben Kabel gibt, und die letzte Ziffer der Seriennummer ungerade ist, das dritte Kabel durchschneiden.<br />Ansonsten, wenn es genau ein gelbes Kabel gibt, und mehr als ein weißes Kabel, das vierte durchschneiden.<br />Ansonsten, wenn es keine roten Kabel gibt, das letzte Kabel durchschneiden.<br />Ansonsten, das vierte Kabel durchschneiden.</tr>			</table>
+				<tr><td><strong><em>3 Kabel:</em></strong>	<br />Wenn es keine roten Kabel gibt, das zweite Kabel durchschneiden.<br />Ansonsten, wenn das letzte Kabel weiß ist, das letzte Kabel durchschneiden.<br />Ansonsten, wenn es mehr als ein blaues Kabel gibt, das letzte blaue Kabel durchschneiden.<br />Ansonsten, das letzte Kabel durchschneiden.</tr><tr><td><strong><em>4 Kabel:</em></strong><br />Wenn es mehr als ein rotes Kabel gibt und die letzte Ziffer der Seriennummer ungerade ist, das letzte rote Kabel durchschneiden.<br />Ansonsten, wenn das letzte Kabel gelb ist und es keine roten Kabel gibt, das erste Kabel durchschneiden.<br />Ansonsten, wenn es genau ein blaues Kabel gibt, das erste Kabel durchschneiden.<br />Ansonsten, wenn es mehr als ein gelbes Kabel gibt, das letzte Kabel durchschneiden.<br />Ansonsten, das zweite Kabel durchschneiden.</tr><tr><td><strong><em>5 Kabel:</em></strong><br />Wenn das letzte Kabel schwarz ist und die letzte Ziffer der Seriennummer ungerade, das vierte Kabel durchschneiden.<br />Ansonsten, wenn es genau ein rotes Kabel gibt und mehr als ein gelbes Kabel, das erste Kabel durchschneiden.<br />Ansonsten, wenn es keine schwarzen Kabel gibt, das zweite Kabel durchschneiden.<br />Ansonsten, das erste Kabel durchschneiden.</tr><tr><td><strong><em>6 Kabel:</em></strong><br />Wenn es keine gelben Kabel gibt und die letzte Ziffer der Seriennummer ungerade ist, das dritte Kabel durchschneiden.<br />Ansonsten, wenn es genau ein gelbes Kabel gibt und mehr als ein weißes Kabel, das vierte durchschneiden.<br />Ansonsten, wenn es keine roten Kabel gibt, das letzte Kabel durchschneiden.<br />Ansonsten, das vierte Kabel durchschneiden.</tr>			</table>
         </div>
         <div class="page-footer relative-footer"></div>
     </div>
@@ -136,11 +136,11 @@
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
     	    <img src="/assets/img/ButtonComponent.svg" class="diagram" />
-            <h2>Bezüglich dem Knopf</h2>
-            <p class="flavour-text">Sie denken vielleicht, dass ein Knopf, der Ihnen befiehlt, ihn zu drücken, relativ unkompliziert ist. Das ist die Denkweise, die Menschen zum Explodieren bringt.</p>
+            <h2>Bezüglich des Knopfes</h2>
+            <p class="flavour-text">Sie denken vielleicht, dass ein Knopf, der Ihnen befiehlt, ihn zu drücken, relativ unkompliziert ist. Das ist die Art von Denken, die Menschen zum Explodieren bringt.</p>
             <p class="appendix-reference">Siehe Anhang A für die Indikatoridentifizierungsreferenz.<br />Siehe Anhang B für die Batterienidentificationsreferenz.</p>		    <p>Folgen Sie diesen Regeln in der Reihenfolge, in der sie aufgelistet sind. Folgen Sie der ersten Anweisung, deren Bedingungen zutreffen.</p>
 		    <ol>
-		    	<li>Wenn der Knopf blau ist, und er mit "Abort" beschriftet ist, halten Sie den Knopf gedrückt und folgen Sie den "Anweisungen für das Loslassen eines gedrückten Knopfs".</li><li>Wenn die Bombe mehr als 1 Batterie hat, und der Knopf mit "Detonate" beschriftet ist, drücken Sie den Knopf und lassen Sie ihn unmittelbar danach wieder los.</li><li>Wenn der Knopf weiß ist, und es ein Indikator mit der Beschriftung CAR leuchtet, halten Sie den Knopf gedrückt und folgen Sie den "Anweisungen für das Loslassen eines gedrückten Knopfs".</li><li>Wenn die Bombe mehr als 2 Batterien hat und ein Indikator mit der Beschriftung FRK leuchtet, drücken Sie den Knopf und lassen Sie ihn unmittelbar danach wieder los.</li><li>Wenn der Knopf gelb ist, halten Sie den Knopf gedrückt und folgen Sie den "Anweisungen für das Loslassen eines gedrückten Knopfs".</li><li>Wenn der Knopf rot ist, und er mit "Hold" beschriftet ist, drücken Sie den Knopf und lassen Sie ihn unmittelbar danach wieder los.</li><li>Andernfalls, halten Sie den Knopf gedrückt und folgen Sie den "Anweisungen für das Loslassen eines grdrückten Knopfs".</li>            </ol>
+		    	<li>Wenn der Knopf blau ist und mit "Abort" beschriftet ist, halten Sie den Knopf gedrückt und folgen Sie den "Anweisungen für das Loslassen eines gedrückten Knopfs".</li><li>Wenn die Bombe mehr als 1 Batterie hat und der Knopf mit "Detonate" beschriftet ist, drücken Sie den Knopf und lassen Sie ihn sofort wieder los.</li><li>Wenn der Knopf weiß ist eine Anzeige mit der Beschriftung CAR leuchtet, halten Sie den Knopf gedrückt und folgen Sie den "Anweisungen für das Loslassen eines gedrückten Knopfs".</li><li>Wenn die Bombe mehr als 2 Batterien hat und eine Anzeige mit der Beschriftung FRK leuchtet, drücken Sie den Knopf und lassen Sie ihn sofort wieder los.</li><li>Wenn der Knopf gelb ist, halten Sie den Knopf gedrückt und folgen Sie den "Anweisungen für das Loslassen eines gedrückten Knopfs".</li><li>Wenn der Knopf rot ist und mit "Hold" beschriftet ist, drücken Sie den Knopf und lassen Sie ihn sofort wieder los.</li><li>Andernfalls, halten Sie den Knopf gedrückt und folgen Sie den "Anweisungen für das Loslassen eines gedrückten Knopfs".</li>            </ol>
 		    <h3>Anweisungen für das Loslassen eines gedrückten Knopfs</h3>
             <p>Wenn Sie den Knopf gedrückt halten, wird ein farbiger Streifen auf der rechten Seite des Moduls aufleuchten. Abhängig von seiner Farbe müssen Sie den Knopf zu einem bestimmten Zeitpunkt loslassen:</p>
             <ul>
@@ -157,16 +157,16 @@
 	    <div class="page-footer absolute-footer"></div>
 	    <div class="page-content">
 		    <img src="/assets/img/KeypadComponent.svg" class="diagram" />
-		    <h2>Bezüglich Tastenfelder</h2>
+		    <h2>Bezüglich der Tastenfelder</h2>
 		    <p class="flavour-text">
 			    Ich bin mir nicht sicher, was diese Symbole sind, aber ich vermute, sie haben mit etwas Okkultem zu tun.
 		    </p>
 			<ul>
 				<li>
-					Nur eine der unteren Spalten hat alle vier Symbole des Tastenfelds.
+					Nur eine der Spalten unten hat alle vier Symbole des Tastenfelds.
 				</li>
 				<li>
-					Drücken Sie die vier Knöpfe in der Reihenfolge, in der sie von oben nach unten in dieser Spalte erscheinen.
+					Drücken Sie die vier Knöpfe in der Reihenfolge, in der sie von oben nach unten in dieser Spalte stehen.
 				</li>
 			</ul>
 			<br/>
@@ -185,16 +185,16 @@
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
     	    <img src="/assets/img/SimonComponent.svg" class="diagram" />
-            <h2>Bezüglich Senso</h2>
+            <h2>Bezüglich des Senso</h2>
             <p class="flavour-text">Es ist wie eins dieser Spiele, das Sie als Kind gespielt haben, wo sie die erscheinende Sequenz nachmachen mussten, nur dass diese hier wahrscheinlich eine billige Kopie ist.</p>
 
 			<ol>
-				<li>Eine der vier farbigen Knöpfe wird blinken.</li>
+				<li>Einer der vier farbigen Knöpfe wird blinken.</li>
 				<li>Mit Hilfe der korrekten Tabelle, drücken Sie den Knopf mit der entsprechenden Farbe.</li>
 				<li>Der vorherige Knopf wird blinken, gefolgt von einem anderen. Wiederholen Sie diese Sequenz mit der Farbenzuordnung.</li>
 				<li>Die Sequenz wird sich jedes Mal um eins verlängern, bis das Modul entschärft ist.</li>
 			</ol>
-		    <img src="/assets/img/SimonComponent_ColourLegend-DE.svg" style="height: 9em; margin: 1em auto; display: block;" alt="Oben: Blau, Links: Rot, Rechts: Geld, Unten: Grün" />
+		    <img src="/assets/img/SimonComponent_ColourLegend-DE.svg" style="height: 9em; margin: 1em auto; display: block;" alt="Oben: Blau, Links: Rot, Rechts: Gelb, Unten: Grün" />
 
     <p>Falls die Seriennummer einen Vokal enthält:<p>
                         <table class="repeaters-table">
@@ -233,9 +233,9 @@
         <div class="page-content">
     	    <img src="/assets/img/WhosOnFirstComponent-DE.svg" class="diagram" />
             <h2>Bezüglich Who’s on First</h2>
-            <p class="flavour-text">Diese Vorrichtung ist wie etwas aus einem Comedy-Sketch, und wäre vielleicht lustig, wenn es nicht Teil einer Bombe wäre. Ich fasse mich hier kurz, da Worte das Ganze nur komplizieren.</p>
+            <p class="flavour-text">Diese Vorrichtung ist wie etwas aus einem Comedy-Sketch und wäre vielleicht lustig, wenn es nicht Teil einer Bombe wäre. Ich fasse mich hier kurz, da Worte das Ganze nur komplizieren.</p>
 		    <ol>
-                        <li>Lesen Sie die Anzeige und folgen Sie den Anweisungen in Schritt 1, um herauszufinden, den Knopf mit welcher Beschriftung zu <u>lesen</u>.</li>
+                        <li>Lesen Sie die Anzeige und folgen Sie den Anweisungen in Schritt 1, um herauszufinden, welche Beschriftung eines bestimmten Knopfes zu <u>lesen</u> ist.</li>
                         <li>Mit Hilfe dieser Beschriftung finden Sie in Schritt 2 heraus, welchen Knopf sie <u>drücken</u> müssen.</li>
 			    <li>Wiederholen Sie das Prozedere, bis das Modul entschärft ist.</li>
 		    </ol>
@@ -278,7 +278,7 @@
                 <li>Die Knopfreihenfolge ist von links nach rechts.</li>
 		    </ul>
             <div class="memory-rules">
-            	<h4>Phase 1:</h4><p>Wenn 1 angezeigt wird, drücken Sie den Knopf in der zweiten Position.<br />Wenn 2 angezeigt wird, drücken Sie den Knopf in der zweiten Position.<br />Wenn 3 angezeigt wird, drücken Sie den Knopf in der dritten Position.<br />Wenn 4 angezeigt wird, drücken Sie den Knopf in der vierten Position.<br /></p><h4>Phase 2:</h4><p>Wenn 1 angezeigt wird, drücken Sie den Knopf mit der Beschriftung "4".<br />Wenn 2 angezeigt wird, drücken Sie den Knopf in der selben Position wie der, die Sie in Phase 1 gedrückt haben.<br />Wenn 3 angezeigt wird, drücken Sie den Knopf in der ersten Position.<br />Wenn 4 angezeigt wird, drücken Sie den Knopf in der selben Position wie der, die Sie in Phase 1 gedrückt haben.<br /></p><h4>Phase 3:</h4><p>Wenn 1 angezeigt wird, drücken Sie den Knopf mit der gleichen Beschriftung wie die des Knopfes, den Sie in Phase 2 gedrückt haben.<br />Wenn 2 angezeigt wird, drücken Sie den Knopf mit der gleichen Beschriftung wie die des Knopfes, den Sie in Phase 1 gedrückt haben.<br />Wenn 3 angezeigt wird, drücken Sie den Knopf in der dritten Position.<br />Wenn 4 angezeigt wird, drücken Sie den Knopf mit der Beschriftung "4".<br /></p><h4>Phase 4:</h4><p>Wenn 1 angezeigt wird, drücken Sie den Knopf in der gleichen Position wie der, die Sie in Phase 1 gedrückt haben.<br />Wenn 2 angezeigt wird, drücken Sie den Knopf in der ersten Position.<br />Wenn 3 angezeigt wird, drücken Sie den Knopf in der selben Position wie der, die Sie in Phase 2 gedrückt haben.<br />Wenn 4 angezeigt wird, drücken Sie den Knopf in der gleichen Position wie der, die Sie in Phase 2 gedrückt haben.<br /></p><h4>Phase 5:</h4><p>Wenn 1 angezeigt wird, drücken Sie den Knopf mit der selben Beschriftung wie die des Knopfes, den Sie in Phase 1 gedrückt haben.<br />Wenn 2 angezeigt wird, drücken Sie den Knopf mit der selben Beschriftung wie die des Knopfes, den Sie in Phase 2 gedrückt haben.<br />Wenn 3 angezeigt wird, drücken Sie den Knopf mit der selben Beschriftung wie die des Knopfes, den Sie in Phase 4 gedrückt haben.<br />Wenn 4 angezeigt wird, drücken Sie den Knopf mit der selben Beschriftung wie die des Knopfes, den Sie in Phase 3 gedrückt haben.<br /></p>            </div>
+            	<h4>Phase 1:</h4><p>Wenn 1 angezeigt wird, drücken Sie den Knopf in der zweiten Position.<br />Wenn 2 angezeigt wird, drücken Sie den Knopf in der zweiten Position.<br />Wenn 3 angezeigt wird, drücken Sie den Knopf in der dritten Position.<br />Wenn 4 angezeigt wird, drücken Sie den Knopf in der vierten Position.<br /></p><h4>Phase 2:</h4><p>Wenn 1 angezeigt wird, drücken Sie den Knopf mit der Beschriftung "4".<br />Wenn 2 angezeigt wird, drücken Sie den Knopf in derselben Position wie der, die Sie in Phase 1 gedrückt haben.<br />Wenn 3 angezeigt wird, drücken Sie den Knopf in der ersten Position.<br />Wenn 4 angezeigt wird, drücken Sie den Knopf in derselben Position wie der, die Sie in Phase 1 gedrückt haben.<br /></p><h4>Phase 3:</h4><p>Wenn 1 angezeigt wird, drücken Sie den Knopf mit der gleichen Beschriftung wie die des Knopfes, den Sie in Phase 2 gedrückt haben.<br />Wenn 2 angezeigt wird, drücken Sie den Knopf mit der gleichen Beschriftung wie die des Knopfes, den Sie in Phase 1 gedrückt haben.<br />Wenn 3 angezeigt wird, drücken Sie den Knopf in der dritten Position.<br />Wenn 4 angezeigt wird, drücken Sie den Knopf mit der Beschriftung "4".<br /></p><h4>Phase 4:</h4><p>Wenn 1 angezeigt wird, drücken Sie den Knopf in der gleichen Position wie der, die Sie in Phase 1 gedrückt haben.<br />Wenn 2 angezeigt wird, drücken Sie den Knopf in der ersten Position.<br />Wenn 3 angezeigt wird, drücken Sie den Knopf in derselben Position wie der, die Sie in Phase 2 gedrückt haben.<br />Wenn 4 angezeigt wird, drücken Sie den Knopf in der gleichen Position wie der, die Sie in Phase 2 gedrückt haben.<br /></p><h4>Phase 5:</h4><p>Wenn 1 angezeigt wird, drücken Sie den Knopf mit derselben Beschriftung wie die des Knopfes, den Sie in Phase 1 gedrückt haben.<br />Wenn 2 angezeigt wird, drücken Sie den Knopf mit derselben Beschriftung wie die des Knopfes, den Sie in Phase 2 gedrückt haben.<br />Wenn 3 angezeigt wird, drücken Sie den Knopf mit derselben Beschriftung wie die des Knopfes, den Sie in Phase 4 gedrückt haben.<br />Wenn 4 angezeigt wird, drücken Sie den Knopf mit derselben Beschriftung wie die des Knopfes, den Sie in Phase 3 gedrückt haben.<br /></p>            </div>
         </div>
         <div class="page-footer relative-footer"></div>
     </div>
@@ -292,7 +292,7 @@
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
     	    <img src="/assets/img/MorseCodeComponent.svg" class="diagram" />
-            <h2>Bezüglich Morse-Code</h2>
+            <h2>Bezüglich des Morse-Codes</h2>
 		        <p class="flavour-text">Eine antiquierte Form nautischer Kommunikation? Was kommt als nächstes? Wenigstens ist es echter Morse-Code, also könnten Sie sogar etwas lernen, wenn Sie aufpassen.</p>
 				<ul>
 					<li>Interpretieren Sie das Signal des blinkenden Lichtes mithilfe der Morse-Code-Legende um eins der Wörter in der Tabelle zu erhalten.</li>
@@ -318,11 +318,11 @@
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
     	    <img src="/assets/img/VennWireComponent.svg" class="diagram" />
-            <h2>Bezüglich Komplizierter Kabel</h2>
+            <h2>Bezüglich komplizierter Kabel</h2>
 		        <p class="flavour-text">Diese Kabel sind nicht wie die anderen. Manche haben Streifen! Das macht sie total anders. Die gute Nachricht ist, dass wir eine prägnante Art gefunden haben, die Anleitung darzustellen. Vielleicht zu prägnant...</p>
 			    <ul>
 				    <li>Schauen Sie sich jedes Kabel an: Es gibt eine LED über dem Kabel und Platz für ein "★"-Symbol unter dem Kabel.</li>
-				    <li><b>Pro</b> Kabel/LED/Symbol-Kombination, ziehen Sie das Venn-Diagram zur Hilfe, um zu entscheiden, ob das Kabel durchgeschnitten werden soll.</li>
+				    <li><b>Pro</b> Kabel/LED/Symbol-Kombination ziehen Sie das Venn-Diagram zu Rate, um zu entscheiden, ob das Kabel durchgeschnitten werden soll.</li>
                     <li>Ein Kabel kann mit mehreren Farben gestreift sein.</li>
 			    </ul>
 
@@ -334,7 +334,7 @@
 		    <div>
 			    <object width="100%" height="100%" id="vennlegend" data="/assets/img/gen/venn/legend-DE.svg" type="image/svg+xml"></object>
 			    <table id="venntable">
-				    <tr><th>Letter</th><th>Instruction</th></tr>
+				    <tr><th>Buchst.</th><th>Anweisung</th></tr>
 				    <tr><td>C</td><td>Kabel durchschneiden</td></tr>
 				    <tr><td>D</td><td>Kabel nicht durchschneiden</td></tr>
 				    <tr><td>S</td><td>Kabel durchschneiden, wenn die letzte Ziffer der Seriennummer gerade ist.</td></tr>
@@ -355,12 +355,12 @@
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
             <img src="/assets/img/WireSequenceComponent.svg" class="diagram" />
-            <h2>Bezüglich Kabel-Sequenzen</h2>
+            <h2>Bezüglich der Kabel-Sequenzen</h2>
             <p class="flavour-text">Es ist schwer zu sagen, wie dieser Mechanismus funktioniert. Die Konstruktion ist ziemlich beeindruckend, aber es muss einen einfacheren Weg geben, 9 Drähte zu verkabeln.</p>
 			<ul>
-			<li>Auf diesem Modul gibt es mehrere Paneele auf denen Kabeln sind, aber nur ein Paneel ist gleichzeitig sichtbar. Wechseln Sie zum nächsten Paneel, indem Sie den Pfeil-nach-unten-Knopf drücken, und zum vorigen mit dem Pfeil-nach-oben-Knopf.</li>
+			<li>Auf diesem Modul gibt es mehrere Paneele auf denen Kabeln sind, aber nur ein Paneel ist zur Zeit sichtbar. Wechseln Sie zum nächsten Paneel, indem Sie den Pfeil-nach-unten-Knopf drücken, und zum vorigen mit dem Pfeil-nach-oben-Knopf.</li>
 			<li>Wechseln Sie nicht zum nächsten Paneel, wenn Sie nicht sicher sind, dass Sie alle notwendigen Kabel auf dem aktuellen Paneel durchgeschnitten haben.</li>
-			<li>Wählen Sie die durchzuschneidenden Kabel mithilfe der folgenden Tabelle aus. Kabelvorkommen sind kumulativ über die gesamten Paneele des Moduls.</li>
+			<li>Wählen Sie die durchzuschneidenden Kabel anhand der folgenden Tabelle aus. Kabelvorkommen sind kumulativ über die gesamten Paneele des Moduls.</li>
 			</ul>
             <div style="clear:both"></div>
 
@@ -376,11 +376,11 @@
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
     	    <img src="/assets/img/MazeComponent.svg" class="diagram" />
-            <h2>Bezüglich Labyrinthe</h2>
-            <p class="flavour-text">Dies scheint eine Art Labyrinth zu sein, wahrscheinlich von einem so einem Restaurant-Platzdeckchen gestohlen.</p>
+            <h2>Bezüglich der Labyrinthe</h2>
+            <p class="flavour-text">Dies scheint eine Art Labyrinth zu sein, wahrscheinlich von so einem Restaurant-Platzdeckchen gestohlen.</p>
             <ul>
                 <li>Finden Sie das Labyrinth mit den passenden kreisrunden Markierungen.</li>
-                <li>Die entschärfende Person muss das weiße Licht mithilfe der Pfeilknöpfe zum rechten Dreieck navigieren.</li>
+                <li>Die entschärfende Person muss das weiße Licht mit Hilfe der Pfeilknöpfe zum roten Dreieck navigieren.</li>
                 <li><strong>Warnung:</strong> Übertreten Sie nicht die Linien, die Sie im Labyrinth sehen können. Diese Linien sind auf der Bombe unsichtbar.</li>
 		    </ul>
             <img class="maze" src="/assets/img/gen/maze/maze0.svg"/>
@@ -405,12 +405,12 @@
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
     	    <img src="/assets/img/PasswordComponent.svg" class="diagram" />
-            <h2>Bezüglich Passwörter</h2>
+            <h2>Bezüglich der Passwörter</h2>
             <p class="flavour-text">Glücklicherweise scheint dieses Passwort nicht den Sicherheitsstandards der Regierung zu genügen: 22 Zeichen, gemischte Groß-/Kleinschreibung, Zahlen in zufälliger Reihenfolge ohne Palindrome über der Länge 3.</p>
 			<ul>
-				<li>Die Knöpfe über und unter dem Buchstaben rotieren durch die Möglichkeiten für diese Position.</li>
+				<li>Die Knöpfe über und unter jedem Buchstaben rotieren durch die Möglichkeiten für diese Position.</li>
 				<li>Nur eine Kombination der verfügbaren Buchstaben wird eins der unteren Passwörter ergeben.</li>
-				<li>Drücken Sie den "submit"-Knopf sobald das korrekte Wort eingestellt wurde.</li>
+				<li>Drücken Sie den "SUBMIT"-Knopf, sobald das korrekte Wort eingestellt wurde.</li>
 			</ul>
 		    <table class="password-table">
 		    	<tr><tr><td>about</td><td>after</td><td>again</td><td>below</td><td>could</td></tr><tr><td>every</td><td>first</td><td>found</td><td>great</td><td>house</td></tr><tr><td>large</td><td>learn</td><td>never</td><td>other</td><td>place</td></tr><tr><td>plant</td><td>point</td><td>right</td><td>small</td><td>sound</td></tr><tr><td>spell</td><td>still</td><td>study</td><td>their</td><td>there</td></tr><tr><td>these</td><td>thing</td><td>think</td><td>three</td><td>water</td></tr><tr><td>where</td><td>which</td><td>world</td><td>would</td><td>write</td></tr>            </table>
@@ -430,8 +430,8 @@
 	        <img src="/assets/img/NeedyComponent.svg" class="diagram" />
 			<div class="new-block-formatting-context">
 				<h1>Abschnitt 2: Anhängliche Module</h1>
-				<p>Anhängliche Module können nicht entschärft werden und stellen eine wiederkehrende Gefahr dar.</p>
-				<p>Anhängliche Module können an ihrem kleinen zweistelligen Timer oben in der Mitte erkannt werden. Mit der Bombe zu interagieren kann sie aktivieren. Wenn sie aktiviert wurden, muss sich um sie gekümmert werden bevor der Timer abläuft, um einen Fehler zu vermeiden.</p>
+				<p>Anhängliche Module können nicht entschärft werden, sondern stellen eine wiederkehrende Gefahr dar.</p>
+				<p>Anhängliche Module können an ihrem kleinen zweistelligen Timer oben in der Mitte erkannt werden. Mit der Bombe zu interagieren kann ihre Aktivierung zur Folge haben. Wenn sie aktiviert wurden, muss sich um sie gekümmert werden bevor der Timer abläuft, um einen Fehler zu vermeiden.</p>
 				<p>Bleiben Sie wachsam: Anhängliche Module können jederzeit reaktiviert werden.</p>
 			</div>
         </div>
@@ -448,9 +448,9 @@
         <div class="page-content">
     	    <img src="/assets/img/NeedyVentComponent.svg" class="diagram" />
             <h2>Bezüglich des Ablassens von Gas</h2>
-            <p class="flavour-text">Hacking ist harte Arbeit! Naja, normalerweise jedenfalls. Diese Aufgabe könnte wahrscheinlich auf von einem betrunkenen Vogel erledigt werden, der immer wieder die selbe Taste drückt.</p>
+            <p class="flavour-text">Hacking ist harte Arbeit! Naja, normalerweise jedenfalls. Diese Aufgabe könnte wahrscheinlich von einem betrunkenen Vogel erledigt werden, der immer wieder dieselbe Taste drückt.</p>
 			<ul>
-				<li>Beantworten Sie die Computer-Anfragen, indem Sie mit "Y" für "Ja" und "N" für "Nein" antworte.</li>
+				<li>Beantworten Sie die Computer-Anfragen, indem Sie mit "Y" für "Ja" und "N" für "Nein" antworten.</li>
 			</ul>
         </div>
         <div class="page-footer relative-footer"></div>
@@ -478,24 +478,24 @@
     <div class="page needy-knob">
         		<div class="page-header">
 			<span class="page-header-doc-title">Keep Talking and Nobody Explodes v. 1</span>
-			<span class="page-header-section-title">Knubbel</span>
+			<span class="page-header-section-title">Drehknauf</span>
 		</div>
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
     	    <img src="/assets/img/NeedyKnobComponent.svg" class="diagram" />
-            <h2>Bezüglich Knubbel</h2>
-            <p class="flavour-text">Unnötig kompliziert und unendlich anhänglich. Stellen Sie sich vor, solch Expertise würde für etwas anderes als diabolische Puzzle verwendet.</p>
+            <h2>Bezüglich des Drehknaufs</h2>
+            <p class="flavour-text">Unnötig kompliziert und unendlich anhänglich. Stellen Sie sich vor, solche Expertise würde für etwas anderes als diabolische Puzzles verwendet.</p>
 			<ul>
-				<li>Der Knubbel kann zu einer von vier Positionen gedreht werden.</li>
-				<li>Der Knubbel muss auf der richtigen Position sein, wenn der Timer des Moduls 0 erreicht.</li>
+				<li>Der Drehknauf kann zu einer von vier Positionen gedreht werden.</li>
+				<li>Der Drehknauf muss in der richtigen Position stehen, wenn der Timer des Moduls 0 erreicht.</li>
 				<li>Die korrekte Position kann mit der An/Aus-Konfiguration der zwölf LEDs bestimmt werden.</li>
-				<li>Knubbelpositionen sind relativ zur "UP"-Beschriftung, die rotiert sein kann.</li>
+				<li>Drehknaufpositionen sind relativ zur "UP"-Beschriftung, die rotiert sein kann.</li>
 			</ul>
             <h3>LED-Konfigurationen</h3>
 
             <h4>Up-Position:</h4><table style="display: inline-table"><tr><td> </td><td> </td><td>X</td><td> </td><td>X</td><td>X</td></tr><tr><td>X</td><td>X</td><td>X</td><td>X</td><td> </td><td>X</td></tr></table><table style="display: inline-table"><tr><td>X</td><td> </td><td>X</td><td> </td><td>X</td><td> </td></tr><tr><td> </td><td>X</td><td>X</td><td> </td><td>X</td><td>X</td></tr></table><h4>Down-Position:</h4><table style="display: inline-table"><tr><td> </td><td>X</td><td>X</td><td> </td><td> </td><td>X</td></tr><tr><td>X</td><td>X</td><td>X</td><td>X</td><td> </td><td>X</td></tr></table><table style="display: inline-table"><tr><td>X</td><td> </td><td>X</td><td> </td><td>X</td><td> </td></tr><tr><td> </td><td>X</td><td> </td><td> </td><td> </td><td>X</td></tr></table><h4>Left-Position:</h4><table style="display: inline-table"><tr><td> </td><td> </td><td> </td><td> </td><td>X</td><td> </td></tr><tr><td>X</td><td> </td><td> </td><td>X</td><td>X</td><td>X</td></tr></table><table style="display: inline-table"><tr><td> </td><td> </td><td> </td><td> </td><td>X</td><td> </td></tr><tr><td> </td><td> </td><td> </td><td>X</td><td>X</td><td> </td></tr></table><h4>Right-Position:</h4><table style="display: inline-table"><tr><td>X</td><td> </td><td>X</td><td>X</td><td>X</td><td>X</td></tr><tr><td>X</td><td>X</td><td>X</td><td> </td><td>X</td><td> </td></tr></table><table style="display: inline-table"><tr><td>X</td><td> </td><td>X</td><td>X</td><td> </td><td> </td></tr><tr><td>X</td><td>X</td><td>X</td><td> </td><td>X</td><td> </td></tr></table>            <br>
             <br>
-            <p class="needy-diagram-label">X = LED ist an</p>
+            <p class="needy-diagram-label">X = LED angeschaltet</p>
         </div>
         <div class="page-footer relative-footer"></div>
     </div>
@@ -508,10 +508,10 @@
 		</div>
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
-            <h2>Appendix A: Indikatoridentifizierungsreferenz</h2>
-            <p>Beschriftete Indikatorlichter können auf den Seiten des Bombemgehäuses gefunden werden.</p>
+            <h2>Appendix A: Referenz zur Identifizierung von Anzeigen</h2>
+            <p>Beschriftete Leuchtanzeigen können auf den Seiten des Bombengehäuses gefunden werden.</p>
             <img src="/assets/img/IndicatorWidget.svg" style="height: 5em; display:block; margin: .6em 0 0;" />
-            <h3>Häufige Indikatoren</h3>
+            <h3>Häufige Anzeigen</h3>
 			<ul>
                 <li>SND</li>
                 <li>CLR</li>
@@ -536,10 +536,10 @@
 		</div>
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
-            <h2>Anhang B: Batterieidentifizierungsreferenz</h2>
-            <p>Häufige Batterietypen können auf den Seiten des Bombemgehäuses gefunden werden.</p>
+            <h2>Anhang B: Referenz zur Identifizierung von Batterien</h2>
+            <p>Häufige Batterietypen können auf den Seiten des Bombengehäuses gefunden werden.</p>
 			<table style="margin-top: 1em;">
-				<tr><th>Battery</th><th>Type</th></tr>
+				<tr><th>Batterie</th><th>Typ</th></tr>
 				<tr><td><img src="/assets/img/appendix-batteries/Battery-AA.svg" style="width: 4.09375em; height: 6.18125em;"></td><td>AA</td></tr>
 				<tr><td><img src="/assets/img/appendix-batteries/Battery-D.svg" style="width: 4.09375em; height: 5.553125em;"></td><td>D</td></tr>
 			</table>
@@ -554,8 +554,8 @@
 		</div>
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
-            <h2>Anhang C: Portidentifizierungsreferenz</h2>
-            <p>Digitale und analoge Schnittstellen könenn auf den Seiten des Bombengehäuses gefunden werden.</p>
+            <h2>Anhang C: Referenz zur Identifizierung von Ports</h2>
+            <p>Digitale und analoge Schnittstellen können auf den Seiten des Bombengehäuses gefunden werden.</p>
 			<table>
 				<tr><th>Port</th><th>Name</th></tr>
 


### PR DESCRIPTION
- Correct grammar (most obviously the wrong title: https://de.wikipedia.org/wiki/Leerzeichen_in_Komposita)
- Correct typos
- Replace some wrong words
- Complete some words missing characters
- Rephrasing of some sentences for more fluid reading, less repetition and better comprehension
- Replace "Knubbel" with the more factual "Drehknauf"
- Rephrase the lengthy appendix heading words